### PR TITLE
make it possible to dynamically detect if stdin is connected 

### DIFF
--- a/main.go
+++ b/main.go
@@ -37,7 +37,19 @@ var (
 )
 
 func main() {
-	check := sensu.NewGoCheck(&plugin.PluginConfig, options, checkArgs, executeCheck, false)
+	useStdin := false
+	fi, err := os.Stdin.Stat()
+	if err != nil {
+		fmt.Printf("Error check stdin: %v\n", err)
+		panic(err)
+	}
+	//Check the Mode bitmask for Named Pipe to indicate stdin is connected
+	if fi.Mode()&os.ModeNamedPipe != 0 {
+		log.Println("using stdin")
+		useStdin = true
+	}
+
+	check := sensu.NewGoCheck(&plugin.PluginConfig, options, checkArgs, executeCheck, useStdin)
 	check.Execute()
 }
 


### PR DESCRIPTION
This change helps to ensure check commands that can "optionally" read stdin will not block waiting for stdin if its not connected.

Logic change basically tests to see if stdin in is a named pipe, indicating the the check resource calling the command is sending data into the command using stdin.  

If stdin is not a named pipe, the check will not automatically read stdin.
